### PR TITLE
Fix automated determination when GCP is cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Environment variables, probably common to all devices so may be defined as balen
 |  Name | Value | Notes |
 |-------|-------|-------|
 | PRODUCER_TOPIC| default `sensors` | Message topic from data producer. `sensors` is used by the [Sensor](https://github.com/balenablocks/sensor) block. |
+| CLOUD_PROVIDER | AWS, AZURE, or GCP | *Optional*, by default Cloud Relay can determine the provider. Useful for a custom provisioning method. |
 
 
 ### AWS

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ async function start() {
             process.env.CLOUD_PROVIDER = 'AWS'
         } else if (process.env.AZURE_HUB_HOST) {
             process.env.CLOUD_PROVIDER = 'AZURE'
-        } else if (process.env.GCP_PROJECT_ID) {
+        } else if (process.env.PROVISION_URL && process.env.PROVISION_URL.includes('cloudfunctions.net')) {
             process.env.CLOUD_PROVIDER = 'GCP'
         } else {
             console.error("Can't determine cloud provider")


### PR DESCRIPTION
Also update README to describe CLOUD_PROVIDER env var, which is useful for custom provisioning scenarios.
