### PR TITLE
Timeout if MQTT connect to GCP does not respond 

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,8 @@ async function start() {
         }
     } catch(e) {
         console.error(e)
+        // Keep it simple; force exit to restart.
+        process.exit(1)
     }
 }
 

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -218,6 +218,9 @@ class GcpMessenger extends Messenger {
     /**
      * Connects to IoT Core messaging. Sets 'connected' property on success. Caller
      * must catch errors.
+     *
+     * Throws Error with code 'connect_timeout' if it gets stuck. Uses CONNECT_TIMEOUT_SEC
+     * env variable to define timeout length or defaults to 30 sec.
      */
     async connect() {
         console.log(`Connecting to host ${this.mqttParams.host}`)
@@ -225,7 +228,23 @@ class GcpMessenger extends Messenger {
         let params = Object.assign({ password: this.createJwt(process.env.GCP_PROJECT_ID, 'ES256') },
                                    this.mqttParams)
         //console.debug("GCP connect params:", JSON.stringify(params))
-        this.mqtt = await mqtt.connectAsync(params)
+
+        // Connect attempt may get stuck; fail on timeout.
+        if (!process.env.CONNECT_TIMEOUT_SEC) {
+            process.env.CONNECT_TIMEOUT_SEC = 30
+        }
+        const connectPromise = mqtt.connectAsync(params)
+        const timeoutPromise = new Promise((resolve, reject) => {
+            setTimeout(reject, process.env.CONNECT_TIMEOUT_SEC * 1000, 'connect_timeout')
+        })
+        try {
+            this.mqtt = await Promise.race([connectPromise, timeoutPromise])
+        } catch(e) {
+            let e2 = new Error(`Failure connecting to IoT Core messaging: ${e}`)
+            e2.code = (e == 'connect_timeout') ? e : 'connect_error'
+            throw e2
+        }
+
         this.connected = true
         setTimeout( async () => { await this.reconnect() }, (process.env.GCP_TOKEN_LIFETIME - process.env.GCP_RENEWAL_START) * 60 * 1000)
         console.log("Connected to IoT Core messaging");
@@ -249,10 +268,8 @@ class GcpMessenger extends Messenger {
 
     /**
      * Close current connection to GCP if any, and reconnect. Implements required
-     * refresh of JWT token.
-     *
-     * Tries to connect three times; exits the process if fails. Best to just try
-     * to restart the process in this case.
+     * refresh of JWT token. Retries on failure if feasible; exits process if
+     * still can't connect.
      */
     async reconnect() {
         console.log("Refreshing IoT Core messaging token")
@@ -269,7 +286,11 @@ class GcpMessenger extends Messenger {
                 await this.connect()
                 break
             } catch(e) {
-                console.warn("Cannot connect to IoT Core:", e)
+                console.warn("Cannot reconnect to IoT Core:", e)
+                if (e.code && e.code == 'connect_timeout') {
+                    // mqtt stuck, too risky to try again
+                    break
+                }
                 if (count < maxTries) {
                     console.log(`Retry in ${delay} seconds`)
                     await new Promise(r => setTimeout(r, delay * 1000))


### PR DESCRIPTION
Added a timeout handler because initial connect attempt never returns or generates a handle-able event.